### PR TITLE
dreamteam-public-api to 0.0.316

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -2,6 +2,9 @@ dependencies:
 - name: dreamteam-hello
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.58
+- name: dreamteam-public-api
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.316
 - alias: expose
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io


### PR DESCRIPTION
Promote dreamteam-public-api to version 0.0.316