### PR TITLE
dreamteam-public-api to 0.0.333

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   version: 0.0.58
 - name: dreamteam-public-api
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.332
+  version: 0.0.333
 - alias: expose
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io


### PR DESCRIPTION
Promote dreamteam-public-api to version 0.0.333