### PR TITLE
dreamteam-public-api to 0.0.637

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   version: 0.0.186
 - name: dreamteam-public-api
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.631
+  version: 0.0.637
 - alias: expose
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io


### PR DESCRIPTION
Promote dreamteam-public-api to version 0.0.637